### PR TITLE
Remove header and subheader, integrate theme toggle

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -11,34 +11,29 @@
 </head>
 <body>
     <div class="container">
-        <header>
-            <div class="header-content">
-                <div class="header-text">
-                    <h1>Course Materials Assistant</h1>
-                    <p class="subtitle">Ask questions about courses, instructors, and content</p>
-                </div>
-                <button id="themeToggle" class="theme-toggle" aria-label="Toggle theme">
-                    <svg class="theme-icon sun-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                        <circle cx="12" cy="12" r="5"/>
-                        <line x1="12" y1="1" x2="12" y2="3"/>
-                        <line x1="12" y1="21" x2="12" y2="23"/>
-                        <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/>
-                        <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/>
-                        <line x1="1" y1="12" x2="3" y2="12"/>
-                        <line x1="21" y1="12" x2="23" y2="12"/>
-                        <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/>
-                        <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
-                    </svg>
-                    <svg class="theme-icon moon-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                        <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
-                    </svg>
-                </button>
-            </div>
-        </header>
-
         <div class="main-content">
             <!-- Left Sidebar -->
             <aside class="sidebar">
+                <!-- Theme Toggle -->
+                <div class="sidebar-section">
+                    <button id="themeToggle" class="theme-toggle" aria-label="Toggle theme">
+                        <svg class="theme-icon sun-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <circle cx="12" cy="12" r="5"/>
+                            <line x1="12" y1="1" x2="12" y2="3"/>
+                            <line x1="12" y1="21" x2="12" y2="23"/>
+                            <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/>
+                            <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/>
+                            <line x1="1" y1="12" x2="3" y2="12"/>
+                            <line x1="21" y1="12" x2="23" y2="12"/>
+                            <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/>
+                            <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
+                        </svg>
+                        <svg class="theme-icon moon-icon" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                            <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+                        </svg>
+                    </button>
+                </div>
+
                 <!-- New Chat Button -->
                 <div class="sidebar-section">
                     <button id="newChatButton" class="new-chat-button">+ NEW CHAT</button>

--- a/frontend/style.css
+++ b/frontend/style.css
@@ -71,48 +71,12 @@ body {
     padding: 0;
 }
 
-/* Header */
-header {
-    background: var(--surface);
-    border-bottom: 1px solid var(--border-color);
-    padding: 1rem 2rem;
-    flex-shrink: 0;
-}
-
-.header-content {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    max-width: 1200px;
-    margin: 0 auto;
-}
-
-.header-text {
-    flex: 1;
-}
-
-header h1 {
-    font-size: 1.75rem;
-    font-weight: 700;
-    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
-    -webkit-background-clip: text;
-    -webkit-text-fill-color: transparent;
-    background-clip: text;
-    margin: 0;
-}
-
-.subtitle {
-    font-size: 0.95rem;
-    color: var(--text-secondary);
-    margin-top: 0.5rem;
-}
-
 /* Theme Toggle Button */
 .theme-toggle {
-    background: none;
-    border: 2px solid var(--border-color);
-    border-radius: 50%;
-    width: 48px;
+    background: var(--background);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    width: 100%;
     height: 48px;
     cursor: pointer;
     display: flex;
@@ -172,6 +136,7 @@ header h1 {
     display: flex;
     overflow: hidden;
     background: var(--background);
+    height: 100vh;
 }
 
 /* Left Sidebar */
@@ -851,26 +816,6 @@ details[open] .suggested-header::before {
     
     .chat-main {
         order: 1;
-    }
-    
-    header {
-        padding: 1rem;
-    }
-    
-    .header-content {
-        flex-direction: row;
-        align-items: center;
-        gap: 1rem;
-    }
-    
-    header h1 {
-        font-size: 1.5rem;
-    }
-    
-    .theme-toggle {
-        width: 40px;
-        height: 40px;
-        flex-shrink: 0;
     }
     
     .chat-messages {


### PR DESCRIPTION
Removes the Course Materials Assistant header and subheading as requested in issue #3. The dark/light mode switcher has been preserved and moved to the sidebar for easy access.

Changes:
- Removed header section with title and subtitle
- Moved theme toggle to sidebar (top position)
- Updated layout for full viewport height
- Maintained all theme functionality

Resolves #3

Generated with [Claude Code](https://claude.ai/code)